### PR TITLE
Fix for no longer works after a period of inactivity

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/MongoDBRiver.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/MongoDBRiver.java
@@ -419,9 +419,9 @@ public class MongoDBRiver extends AbstractRiverComponent implements River {
 					}
 
 					while (oplogCursor.hasNext()) {
-                        DBObject item = oplogCursor.next();
-                        processOplogEntry(item);
-                    }
+						DBObject item = oplogCursor.next();
+						processOplogEntry(item);
+					}
 					Thread.sleep(5000);
 				} catch (MongoException mEx) {
 					logger.error("Mongo gave an exception", mEx);


### PR DESCRIPTION
https://github.com/richardwilly98/elasticsearch-river-mongodb/issues/10

Hello,

Yesterday i've modified elasticsearch-river-mongodb : this fix the issue #10.

Based on log ( I've turned on DEBUG onto ElasticSearch), 
i'm seeing that newer entry are added

<pre><code>
[2012-06-11 11:45:17,795][DEBUG][river.mongodb            ] [xxx] [mongodb][yyy] Update operation - id: zzzzzzzzzzzzz - contains attachment: false
</code></pre>


and with graph reports ( munin with https://github.com/revinate/elasticsearch-munin-plugins ),
there's activity for 'getmore' calls :  
http://imgur.com/jhbQW 

previously it was failing after 1 hour or so ( green line at bottom ).
