### PR TITLE
Allow the script filters to modify the doc ID

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/MongoDBRiver.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/MongoDBRiver.java
@@ -744,6 +744,7 @@ public class MongoDBRiver extends AbstractRiverComponent implements River {
 				String type = extractType(ctx);
 				String parent = extractParent(ctx);
 				String routing = extractRouting(ctx);
+				objectId = extractObjectId(ctx, objectId);
 				if (logger.isDebugEnabled()) {
 					logger.debug(
 							"Operation: {} - index: {} - type: {} - routing: {} - parent: {}",
@@ -827,6 +828,13 @@ public class MongoDBRiver extends AbstractRiverComponent implements River {
 			}
 		}
 
+		private String extractObjectId(Map<String, Object> ctx, String objectId) {
+			String id =  (String) ctx.get("id");
+			if (id == null) {
+				id = objectId;
+			}
+			return id;
+		}
 		private String extractParent(Map<String, Object> ctx) {
 			return (String) ctx.get("_parent");
 		}


### PR DESCRIPTION
Retrieve and use the objectId from the script filter context (if a script filter has been configured).
