### PR TITLE
Fix the issue 95 reproduction test case

### DIFF
--- a/resources/issues/95/01_create-river.sh
+++ b/resources/issues/95/01_create-river.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+curl -XPUT "http://localhost:9200/_river/river95/_meta" -d @"${DIR}/mongodb-simple-river.json"

--- a/resources/issues/95/02_test-issue-95.bat
+++ b/resources/issues/95/02_test-issue-95.bat
@@ -1,3 +1,3 @@
-﻿%MONGO_HOME%\bin\mongo < test-issue-95.js
+﻿%MONGO_HOME%\bin\mongo mydb95 < test-issue-95.js
 pause
 curl -XGET localhost:9200/mydb95/_search?q=content:test91

--- a/resources/issues/95/02_test-issue-95.sh
+++ b/resources/issues/95/02_test-issue-95.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+mongo mydb95 < "${DIR}/test-issue-95.js"
+sleep 1
+curl -XGET localhost:9200/mydb95/_search?q=content:test91

--- a/resources/issues/95/test-issue-95.js
+++ b/resources/issues/95/test-issue-95.js
@@ -1,8 +1,5 @@
-﻿use mydb95
-var o =
-{
+db.mycollection95.save({
   "title": "中华料理 Chinese Cuisine",
   "tags": ["中国", "食物", "Chinese", "food"],
   "content": "中国菜很好吃。"
-}
-db.mycollec95.save(o)
+});


### PR DESCRIPTION
Fix the issue 95 reproduction test case by saving data to the MongoDB collection that was specified in the river configuration (mycollection95 vs. mycollec95). Allow the test case to be run on Linux.
