### PR TITLE
Add import_filter to MongoDBRiverDefinition.

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/MongoDBRiverDefinition.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/MongoDBRiverDefinition.java
@@ -60,6 +60,7 @@ public class MongoDBRiverDefinition {
     public final static String ADVANCED_TRANSFORMATION_FIELD = "advanced_transformation";
     public final static String PARENT_TYPES_FIELD = "parent_types";
     public final static String FILTER_FIELD = "filter";
+    public final static String IMPORT_FILTER_FIELD = "import_filter";
     public final static String CREDENTIALS_FIELD = "credentials";
     public final static String USER_FIELD = "user";
     public final static String PASSWORD_FIELD = "password";
@@ -87,6 +88,7 @@ public class MongoDBRiverDefinition {
     private final String mongoCollection;
     private final boolean mongoGridFS;
     private final String mongoFilter;
+    private final String mongoImportFilter;
     // mongodb.credentials
     private final String mongoAdminUser;
     private final String mongoAdminPassword;
@@ -128,6 +130,7 @@ public class MongoDBRiverDefinition {
         private String mongoCollection;
         private boolean mongoGridFS;
         private String mongoFilter = "";
+        private String mongoImportFilter = "";
         // mongodb.credentials
         private String mongoAdminUser = "";
         private String mongoAdminPassword = "";
@@ -189,6 +192,11 @@ public class MongoDBRiverDefinition {
 
         public Builder mongoFilter(String mongoFilter) {
             this.mongoFilter = mongoFilter;
+            return this;
+        }
+
+        public Builder mongoImportFilter(String mongoImportFilter) {
+            this.mongoImportFilter = mongoImportFilter;
             return this;
         }
 
@@ -521,6 +529,12 @@ public class MongoDBRiverDefinition {
                 builder.mongoFilter("");
             }
 
+            if (mongoSettings.containsKey(IMPORT_FILTER_FIELD)) {
+                builder.mongoImportFilter(XContentMapValues.nodeStringValue(mongoSettings.get(IMPORT_FILTER_FIELD), ""));
+            } else {
+                builder.mongoImportFilter("");
+            }
+
             if (mongoSettings.containsKey(SCRIPT_FIELD)) {
                 String scriptType = "js";
                 builder.script(mongoSettings.get(SCRIPT_FIELD).toString());
@@ -608,6 +622,7 @@ public class MongoDBRiverDefinition {
         this.mongoCollection = builder.mongoCollection;
         this.mongoGridFS = builder.mongoGridFS;
         this.mongoFilter = builder.mongoFilter;
+        this.mongoImportFilter = builder.mongoImportFilter;
         // mongodb.credentials
         this.mongoAdminUser = builder.mongoAdminUser;
         this.mongoAdminPassword = builder.mongoAdminPassword;
@@ -666,6 +681,10 @@ public class MongoDBRiverDefinition {
 
     public String getMongoFilter() {
         return mongoFilter;
+    }
+
+    public String getMongoImportFilter() {
+        return mongoImportFilter;
     }
 
     public String getMongoAdminUser() {

--- a/src/main/java/org/elasticsearch/river/mongodb/Slurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/Slurper.java
@@ -140,9 +140,15 @@ class Slurper implements Runnable {
         logger.info("MongoDBRiver is beginning initial import of " + slurpedCollection.getFullName());
         BSONTimestamp startTimestamp = getCurrentOplogTimestamp();
         DBCursor cursor = null;
+        DBObject filter = new BasicDBObject();
+
+        if (!definition.getMongoImportFilter().isEmpty()) {
+            filter = (DBObject) JSON.parse(definition.getMongoImportFilter());
+        }
+
         try {
             if (!definition.isMongoGridFS()) {
-                cursor = slurpedCollection.find();
+                cursor = slurpedCollection.find(filter);
                 while (cursor.hasNext()) {
                     DBObject object = cursor.next();
                     addToStream(MongoDBRiver.OPLOG_INSERT_OPERATION, null, applyFieldFilter(object));


### PR DESCRIPTION
This allows filtering of the initial import.

I noticed that the initial import ignores the defined filter in the MongoDBRiverDefinition. I first tried to feed the configured filter to `slurpedCollection.find()`, but that does not work because the oplog filter needs the `o.` prefix. And that does not work with the regular `find()` on the collection. So I created another filter option. (`import_filter`)

Not sure if you want to merge this as it is. Maybe it would be nicer to only have one filter definition that works for the initial import and the oplog filter. (by prepending the `o.` prefix automatically or something like that)

It works for me and helps me to filter the initial import so I wanted to share it.

Attention: I don't know Java, so please double check this code. ;)
