### PR TITLE
Remove the sonatype repository as it causes all types of errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,12 +36,6 @@
 		</developer>
 	</developers>
 
-	<parent>
-		<groupId>org.sonatype.oss</groupId>
-		<artifactId>oss-parent</artifactId>
-		<version>7</version>
-	</parent>
-
 	<properties>
 		<elasticsearch.version>1.2.1</elasticsearch.version>
 		<mongo-java-driver.version>2.12.2</mongo-java-driver.version>
@@ -80,13 +74,6 @@
 			</build>
 		</profile>
 	</profiles>
-	<repositories>
-		<repository>
-			<id>sonatype-releases</id>
-			<name>Sonatype Releases Repository</name>
-			<url>http://oss.sonatype.org/content/repositories/releases</url>
-		</repository>
-	</repositories>
 
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
@richardwilly98 part of my pull request to fix the tests wasn't merged so I still have lots of issues with the latest master

Suggest blasting away ~/.m2 directory and so that dependencies are redownloaded from Maven Central
