### PR TITLE
fix: do not import system tables when using import_all_collections

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/Slurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/Slurper.java
@@ -101,8 +101,10 @@ class Slurper implements Runnable {
                         }
                         if (definition.isImportAllCollections()) {
                             for (String name : slurpedDb.getCollectionNames()) {
-                                DBCollection collection = slurpedDb.getCollection(name);
-                                startTimestamp = doInitialImport(collection);
+                                if (name.length() < 7 || !name.substring(0, 7).equals("system.")) {
+                                    DBCollection collection = slurpedDb.getCollection(name);
+                                    startTimestamp = doInitialImport(collection);
+                                }
                             }
                         } else {
                             DBCollection collection = slurpedDb.getCollection(definition.getMongoCollection());


### PR DESCRIPTION
Importing system tables feels weird to me.

This patch is also motivated by the fact that you can miss permissions to access those tables and when this is the case, it makes the whole river fail.
