### PR TITLE
Allow users to authenticate against different database

### DIFF
--- a/src/main/java/org/elasticsearch/rest/action/mongodb/RestMongoDBRiverAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/mongodb/RestMongoDBRiverAction.java
@@ -49,7 +49,7 @@ public class RestMongoDBRiverAction extends BaseRestHandler {
         logger.debug("uri: {}", uri);
         logger.debug("action: {}", request.param("action"));
 
-        if (uri.indexOf("list") > -1) {
+        if (request.path().endsWith("list")) {
             list(request, channel);
             return;
         } else if (uri.endsWith("start")) {
@@ -145,7 +145,7 @@ public class RestMongoDBRiverAction extends BaseRestHandler {
     }
 
     private Map<String, Object> getRivers(int page, int count) {
-    	int from = (page - 1) * count;
+        int from = (page - 1) * count;
         SearchResponse searchResponse = client.prepareSearch(riverIndexName)
                 .setQuery(QueryBuilders.queryString(MongoDBRiver.TYPE).defaultField("type")).setFrom(from).setSize(count).get();
         long totalHits = searchResponse.getHits().totalHits();

--- a/src/main/java/org/elasticsearch/river/mongodb/MongoDBRiver.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/MongoDBRiver.java
@@ -298,10 +298,10 @@ public class MongoDBRiver extends AbstractRiverComponent implements River {
 
     private DB getAdminDb() {
         if (adminDb == null) {
-        	if(!definition.getMongoAdminAuthDatabase().isEmpty()) {
-	        	adminDb = getMongoClient().getDB(definition.getMongoAdminAuthDatabase());
+        	if (!definition.getMongoAdminAuthDatabase().isEmpty()) {
+	            adminDb = getMongoClient().getDB(definition.getMongoAdminAuthDatabase());
         	} else {
-            	adminDb = getMongoClient().getDB(MONGODB_ADMIN_DATABASE);
+                adminDb = getMongoClient().getDB(MONGODB_ADMIN_DATABASE);
             }
             if (logger.isTraceEnabled()) {
                 logger.trace("MongoAdminUser: {} - authenticated: {}", definition.getMongoAdminUser(), adminDb.isAuthenticated());

--- a/src/main/java/org/elasticsearch/river/mongodb/Slurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/Slurper.java
@@ -280,13 +280,13 @@ class Slurper implements Runnable {
 
     protected boolean assignCollections() {
     	DB adminDb;
-    	if(!definition.getMongoAdminAuthDatabase().isEmpty()) {
+    	if (!definition.getMongoAdminAuthDatabase().isEmpty()) {
 	    	adminDb = mongo.getDB(definition.getMongoAdminAuthDatabase());
     	} else {
 	    	adminDb = mongo.getDB(MongoDBRiver.MONGODB_ADMIN_DATABASE);
     	}
     	
-    	if(!definition.getMongoLocalAuthDatabase().isEmpty()) {
+    	if (!definition.getMongoLocalAuthDatabase().isEmpty()) {
     		logger.info("Local DB auth against "+definition.getMongoLocalAuthDatabase()+" user: "+definition.getMongoLocalUser());
 	    	oplogDb = mongo.getDB(definition.getMongoLocalAuthDatabase());
     	} else {


### PR DESCRIPTION
For use with an oplog that must be accessed via a user on a database other than local i have added a new item into the credentials config to choose user source.

the updated credentials look like:
"credentials":[
  {
    "db":"local",
    "password":"password",
    "user":"test_db_user",
    "auth":"test_db"
  }
]

where "auth" is the user source

I have currently built this code against 2.0.0 version as our environment requires, but i see no breaking changes that will stop from working on the latest snapshot
