### PR TITLE
Fixes #240 and #216 Retry mongodb connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ test-output/
 .externalToolBuilders
 maven-eclipse.xml
 
+.idea
+*.iml
+
 ## eclipse ignores (use 'mvn eclipse:eclipse' to build eclipse projects)
 ## The only configuration files which are not ignored are certain files in
 ## .settings (as listed below) since these files ensure common coding 


### PR DESCRIPTION
I just fixed that for me (mongodb 2.4 and ES 1.2) on top of the 2.0.1 release, but if it can help other people!
- Retry if mongodb is down while river init till mongodb comes up
- Retry if mongodb isn't reachable while processing the oplog

Can be install directly 

```
plugin --install com.synhaptein/elasticsearch-river-mongodb/2.0.1.1
```
