### PR TITLE
Use #addQueryToStream() when processing the full oplog

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/Slurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/Slurper.java
@@ -360,7 +360,7 @@ class Slurper implements Runnable {
 
     private DBCursor processFullOplog() throws InterruptedException, SlurperException {
         Timestamp<?> currentTimestamp = getCurrentOplogTimestamp();
-        addInsertToStream(currentTimestamp, null);
+        addQueryToStream(Operation.INSERT, currentTimestamp, null, null);
         return oplogCursor(currentTimestamp);
     }
 


### PR DESCRIPTION
96815583 changed this to #addInsertToStream() with a 'null' data object, which actually leads to
NPEs in the Indexer which unconditionally dereferences the data object.

From a unit test failure I saw once:

```
[mongod output] [2014-11-04 16:46:04,557][TRACE][org.elasticsearch.river.mongodb.Slurper] addToStream - operation [INSERT], currentTimestamp [Timestamp.BSON(ts={ "$ts" : 1415115964 , "$inc" : 1})], data [null], collection [r0-rivermongomapreducetest-1415115859014]
Exception in thread "elasticsearch[Ezekiel Sims][mongodb_river_indexer][T#1]" java.lang.NullPointerException
    at org.elasticsearch.river.mongodb.Indexer.processBlockingQueue(Indexer.java:109)
    at org.elasticsearch.river.mongodb.Indexer.run(Indexer.java:70)
    at java.lang.Thread.run(Thread.java:745)
```
