### PR TITLE
Remove the commented setting of "autoConnectRetry"

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/MongoDBRiverDefinition.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/MongoDBRiverDefinition.java
@@ -531,14 +531,8 @@ public class MongoDBRiverDefinition {
             }
             builder.mongoServers(mongoServers);
 
-            MongoClientOptions.Builder mongoClientOptionsBuilder = MongoClientOptions.builder()/*
-                                                                                                * .
-                                                                                                * autoConnectRetry
-                                                                                                * (
-                                                                                                * true
-                                                                                                * )
-                                                                                                */
-            .socketKeepAlive(true);
+            MongoClientOptions.Builder mongoClientOptionsBuilder = MongoClientOptions.builder()
+                    .socketKeepAlive(true);
 
             // MongoDB options
             if (mongoSettings.containsKey(OPTIONS_FIELD)) {


### PR DESCRIPTION
This option is deprecated without replacement, and doesn't really make sense: if connecting fails before
the connect timeout then it likely won't get fixed by retrying: it must be something other than just time that
prevents us from connecting.
