### PR TITLE
Use the actual name of the collection for the operations

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/Slurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/Slurper.java
@@ -644,7 +644,7 @@ class Slurper implements Runnable {
         if (collection == null) {
             for (String name : slurpedDb.getCollectionNames()) {
                 DBCollection slurpedCollection = slurpedDb.getCollection(name);
-                addQueryToStream(operation, currentTimestamp, update, collection, slurpedCollection);
+                addQueryToStream(operation, currentTimestamp, update, name, slurpedCollection);
             }
         } else {
             DBCollection slurpedCollection = slurpedDb.getCollection(collection);


### PR DESCRIPTION
When we have to scan the collections because we couldn't determine which collection
was affected by the update we want to report the change nonetheless with the name, not
as 'null'.
