### PR TITLE
fix error when collection name contains a dot

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/Slurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/Slurper.java
@@ -468,7 +468,7 @@ class Slurper implements Runnable {
     }
 
     private String getCollectionFromNamespace(String namespace) {
-        if (namespace.startsWith(definition.getMongoDb()) && CharMatcher.is('.').countIn(namespace) == 1) {
+        if (namespace.startsWith(definition.getMongoDb() + '.')) {
             return namespace.substring(definition.getMongoDb().length() + 1);
         }
         logger.error("Cannot get collection from namespace [{}]", namespace);


### PR DESCRIPTION
Fix errors like :

```
[2014-11-07 14:05:04,523][INFO ][org.elasticsearch.river.mongodb.Slurper] Cannot get collection from namespace [coorpacademy.system.indexes]
```
