### PR TITLE
Driver 2.13.0 rc0

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/OplogSlurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/OplogSlurper.java
@@ -465,6 +465,9 @@ class OplogSlurper implements Runnable {
                 | Bytes.QUERYOPTION_OPLOGREPLAY;
 
         DBCursor cursor = oplogCollection.find(indexFilter).setOptions(options);
+        // Disable tracking of received batch sizes to avoid out-of-memory situations
+        // https://jira.mongodb.org/browse/JAVA-591
+        cursor.disableBatchSizeTracking();
 
         // Toku sometimes gets stuck without this hint:
         if (indexFilter.containsField(MongoDBRiver.MONGODB_ID_FIELD)) {


### PR DESCRIPTION
This batch updates the driver, and then uses the newly-added-and-deprecated `#disableBatchSizeTracking()` function on the oplog cursors.

Release announcement: https://github.com/mongodb/mongo-java-driver/releases/tag/r2.13.0-rc0