### PR TITLE
Make the 'tailerThreads' member final

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/MongoDBRiver.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/MongoDBRiver.java
@@ -119,7 +119,7 @@ public class MongoDBRiver extends AbstractRiverComponent implements River {
     protected final ScriptService scriptService;
     protected final SharedContext context;
 
-    protected volatile List<Thread> tailerThreads = Lists.newArrayList();
+    protected final List<Thread> tailerThreads = Lists.newArrayList();
     protected volatile Thread indexerThread;
     protected volatile Thread statusThread;
 


### PR DESCRIPTION
'tailerThreads' is never changed after construction, although the content may change when the river
is started or stopped. This is however not covered by the 'volatile' keyword, and there is really no
need to allow concurrent modifications of the content (at this point).
