### PR TITLE
Use distinct labels for the tokumx and mongodb outputs

### DIFF
--- a/src/test/java/org/elasticsearch/river/mongodb/RiverMongoDBTestAbstract.java
+++ b/src/test/java/org/elasticsearch/river/mongodb/RiverMongoDBTestAbstract.java
@@ -129,22 +129,22 @@ public abstract class RiverMongoDBTestAbstract {
         VANILLA("mongodb", true, true) {
             @Override
             public Starter<IMongodConfig, MongodExecutable, MongodProcess> newStarter() {
-                return MongodStarter.getInstance(getRuntimeConfig());
+                return MongodStarter.getInstance(newRuntimeConfig());
             }
 
             @Override
-            public RuntimeConfigBuilder getRuntimeConfigBuilder() {
+            public RuntimeConfigBuilder newRuntimeConfigBuilder() {
                 return new RuntimeConfigBuilder();
             }
         },
         TOKUMX("tokumx", tokuIsSupported(), false) {
             @Override
             public Starter<IMongodConfig, MongodExecutable, MongodProcess> newStarter() {
-                return TokuMXStarter.getInstance(getRuntimeConfig());
+                return TokuMXStarter.getInstance(newRuntimeConfig());
             }
 
             @Override
-            public RuntimeConfigBuilder getRuntimeConfigBuilder() {
+            public RuntimeConfigBuilder newRuntimeConfigBuilder() {
                 return new TokuRuntimeConfigBuilder();
             }
         };
@@ -161,10 +161,10 @@ public abstract class RiverMongoDBTestAbstract {
 
         public abstract Starter<IMongodConfig, MongodExecutable, MongodProcess> newStarter();
 
-        protected abstract RuntimeConfigBuilder getRuntimeConfigBuilder();
+        protected abstract RuntimeConfigBuilder newRuntimeConfigBuilder();
 
-        protected IRuntimeConfig getRuntimeConfig() {
-            return getRuntimeConfigBuilder()
+        protected IRuntimeConfig newRuntimeConfig() {
+            return newRuntimeConfigBuilder()
                     .defaults(Command.MongoD)
                     .processOutput(ProcessOutput.getDefaultInstance(configKey))
                     .build();


### PR DESCRIPTION
When the tests are running they produce a lot of output. Understanding the output on is complicated further in cases where both tokumx and mongodb are used by the tests, as those outputs overlap.

This can be improved by using a different label for the outputs of the both types, leading to something like this 

```
[tokumx output] Mon Dec 15 16:40:36.095 [initandlisten] connection accepted from 127.0.0.1:41572 #47 (10 connections now open)
[tokumx output] 2014-12-15T16:40:36.222+0100 [conn56] end connection 127.0.0.1:53815 (15 connections now open)
[mongodb output] 2014-12-15T16:40:36.222+0100 [initandlisten] connection accepted from 127.0.0.1:53839 #61 (16 connections now open)
[mongodb output] [2014-12-15 16:40:36,459][DEBUG][org.elasticsearch.river.mongodb.simple.RiverMongoDbRefTest] Running Cluster Health
[2014-12-15 16:40:36,459][INFO ][org.elasticsearch.river.mongodb.simple.RiverMongoDbRefTest] Done Cluster Health, status GREEN
[2014-12-15 16:40:36,459][INFO ][org.elasticsearch.river.mongodb.simple.RiverMongoDbRefTest] Drop database d-rivermongodbreftest-1418657420773
Mon Dec 15 16:40:36.459 [conn10] dropDatabase d-rivermongodbreftest-1418657420773
[tokumx output] 2014-12-15T16:40:36.474+0100 [initandlisten] connection accepted from 127.0.0.1:53840 #62 (17 connections now open)
[mongodb output] 2014-12-15T16:40:36.474+0100 [conn57] end connection 127.0.0.1:53816 (15 connections now open)
[mongodb output] Mon Dec 15 16:40:37.026 [conn10] command d-rivermongodbreftest-1418657420773.$cmd command: { dropDatabase: 1 } ntoreturn:1 keyUpdates:0 locks(micros) W:567120 reslen:86 567ms
```

Note that the output is _still_ intermixed sometimes, which probably can only be fixed properly by using a distinct logger for each of the `mongod` processes, the elasticsearch node, and the actual test code. But, at least it gets somewhat clearer IMHO.
