### PR TITLE
Use MongoDB 2.6.6 in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Note that you must be using MongoDB replica sets since this river tails the oplo
 
 | MongoDB River Plugin     | ElasticSearch    | MongoDB       | TokuMX        |
 |--------------------------|------------------|---------------|---------------|
-| master                   | 1.4.0            | 2.6.5         | 1.5.1         |
+| master                   | 1.4.0            | 2.6.6         | 1.5.1         |
 | 2.0.4                    | 1.4.0            | 2.6.5         | 1.5.1         |
 | 2.0.2                    | 1.3.5            | 2.6.5         | 1.5.1         |
 | 2.0.1                    | 1.2.2            | 2.4.9 -> 2.6.3| 1.5.0         |

--- a/src/test/resources/settings.yml
+++ b/src/test/resources/settings.yml
@@ -28,7 +28,7 @@ plugins:
   lang-javascript: elasticsearch/elasticsearch-lang-javascript/2.4.1
 
 mongodb:
-  version: 2.6.5
+  version: 2.6.6
   use_dynamic_ports: false
 
 tokumx:


### PR DESCRIPTION
Tests passed on Linux/amd64.
