### PR TITLE
Clear unused flags to reduce load on cluster.

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/MongoDBRiverBulkProcessor.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/MongoDBRiverBulkProcessor.java
@@ -216,7 +216,7 @@ public class MongoDBRiverBulkProcessor {
     }
 
     private long getBulkQueueSize() {
-        NodesInfoResponse response = client.admin().cluster().prepareNodesInfo().setThreadPool(true).get();
+        NodesInfoResponse response = client.admin().cluster().prepareNodesInfo().clear().setThreadPool(true).get();
         for (NodeInfo node : response.getNodes()) {
             Iterator<Info> iterator = node.getThreadPool().iterator();
             while (iterator.hasNext()) {


### PR DESCRIPTION
A regression was introduced in the ES stats API call somewhere between ES 1.2.x. and 1.4.x that makes stats calls a lot more expensive. See https://github.com/elasticsearch/elasticsearch/issues/9681, https://groups.google.com/d/topic/elasticsearch/bOyBxgI9cMA/discussion and https://github.com/elasticsearch/elasticsearch/pull/9666 which are related issues. A ticket describing the exact issue is yet to be filed but I've been working offline on this with @imotov. The river makes frequent calls to the stats API which compounds the issue. Requesting only the needed thread_pool flags will contribute to mitigating the load on the cluster while the ES team fixes the stats issue on their side.
