### PR TITLE
Fix auth problems for Mongo 3 

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/MongoClientService.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/MongoClientService.java
@@ -63,13 +63,13 @@ public class MongoClientService extends AbstractLifecycleComponent<MongoClientSe
 
             List<MongoCredential> mongoCredentials = new ArrayList<>();
             if (!Strings.isNullOrEmpty(definition.getMongoLocalUser()) && !Strings.isNullOrEmpty(definition.getMongoLocalPassword())) {
-                mongoCredentials.add(MongoCredential.createMongoCRCredential(
+                mongoCredentials.add(MongoCredential.createCredential(
                         definition.getMongoLocalUser(),
                         !Strings.isNullOrEmpty(definition.getMongoLocalAuthDatabase()) ? definition.getMongoLocalAuthDatabase() : MongoDBRiver.MONGODB_LOCAL_DATABASE,
                         definition.getMongoLocalPassword().toCharArray()));
             }
             if (!Strings.isNullOrEmpty(definition.getMongoAdminUser()) && !Strings.isNullOrEmpty(definition.getMongoAdminPassword())) {
-                mongoCredentials.add(MongoCredential.createMongoCRCredential(
+                mongoCredentials.add(MongoCredential.createCredential(
                         definition.getMongoAdminUser(),
                         !Strings.isNullOrEmpty(definition.getMongoAdminAuthDatabase()) ? definition.getMongoAdminAuthDatabase() : MongoDBRiver.MONGODB_ADMIN_DATABASE,
                         definition.getMongoAdminPassword().toCharArray()));


### PR DESCRIPTION
Fix auth problems for Mongo 3 (`createMongoCRCredential` doesn't work anymore. But `createCredential` works both for Mongo 2.x and Mongo 3: [see the explanation](http://www.kennygorman.com/mongodb-2.8-authentication-changes)).