### PR TITLE
Fix NPE when we cannot get the _id field

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/CollectionSlurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/CollectionSlurper.java
@@ -28,6 +28,8 @@ import com.mongodb.gridfs.GridFS;
 import com.mongodb.gridfs.GridFSDBFile;
 import com.mongodb.gridfs.GridFSFile;
 
+import static org.elasticsearch.river.mongodb.util.MongoDBHelper.getMongoDBIdField;
+
 class CollectionSlurper extends MongoDBRiverComponent {
 
     private final MongoDBRiverDefinition definition;
@@ -232,7 +234,7 @@ class CollectionSlurper extends MongoDBRiverComponent {
         if (data == null) {
             return null;
         } else {
-            return data.containsField(MongoDBRiver.MONGODB_ID_FIELD) ? data.get(MongoDBRiver.MONGODB_ID_FIELD).toString() : null;
+            return getMongoDBIdField(data);
         }
     }
 

--- a/src/main/java/org/elasticsearch/river/mongodb/OplogSlurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/OplogSlurper.java
@@ -27,6 +27,8 @@ import com.mongodb.gridfs.GridFSDBFile;
 import com.mongodb.gridfs.GridFSFile;
 import com.mongodb.util.JSONSerializers;
 
+import static org.elasticsearch.river.mongodb.util.MongoDBHelper.getMongoDBIdField;
+
 class OplogSlurper extends MongoDBRiverComponent implements Runnable {
 
     class SlurperException extends Exception {
@@ -524,7 +526,7 @@ class OplogSlurper extends MongoDBRiverComponent implements Runnable {
         if (data == null) {
             return null;
         } else {
-            return data.containsField(MongoDBRiver.MONGODB_ID_FIELD) ? data.get(MongoDBRiver.MONGODB_ID_FIELD).toString() : null;
+            return getMongoDBIdField(data);
         }
     }
 

--- a/src/main/java/org/elasticsearch/river/mongodb/util/MongoDBHelper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/util/MongoDBHelper.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.joda.time.DateTimeZone;
 import org.elasticsearch.common.joda.time.format.ISODateTimeFormat;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.river.mongodb.MongoDBRiver;
 
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
@@ -198,5 +199,14 @@ public abstract class MongoDBHelper {
             object = MongoDBHelper.applyIncludeFields(object, includeFields);
         }
         return object;
+    }
+
+
+    public static String getMongoDBIdField(DBObject data) {
+        if(data.containsField(MongoDBRiver.MONGODB_ID_FIELD)) {
+            final Object value = data.get(MongoDBRiver.MONGODB_ID_FIELD);
+            return value != null ? value.toString() : null;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Sometimes `_id` field occasionally may be null. This leads to the total river failure. I believe it should be steady to any data-related problems.
