### PR TITLE
Fix error when we could not get objectId from oplog

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/OplogSlurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/OplogSlurper.java
@@ -225,7 +225,12 @@ class OplogSlurper implements Runnable {
             }
         }
 
-        String objectId = getObjectIdFromOplogEntry(entry);
+        String objectId = null;
+        try {
+            objectId = getObjectIdFromOplogEntry(entry);
+        } catch (Exception e) {
+            logger.warn("Failed to get ObjectId from Oplog Entry!", e);
+        }
         if (operation == Operation.DELETE) {
             // Include only _id in data, as vanilla MongoDB does, so
             // transformation scripts won't be broken by Toku


### PR DESCRIPTION
Sometimes (it happened to us two or more times) `getObjectIdFromOplogEntry` throws the exceptions, which leads to river failure. I'm not sure it is a good idea to catch any exception here. But I believe such cases must not affect the indexing service availability.
