### PR TITLE
Fix old mongo with new driver compatibility

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/OplogSlurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/OplogSlurper.java
@@ -467,7 +467,11 @@ class OplogSlurper implements Runnable {
         DBCursor cursor = oplogCollection.find(indexFilter).setOptions(options);
         // Disable tracking of received batch sizes to avoid out-of-memory situations
         // https://jira.mongodb.org/browse/JAVA-591
-        cursor.disableBatchSizeTracking();
+        try {
+            cursor.disableBatchSizeTracking();
+        } catch (NoSuchMethodError e) {
+            logger.warn("ES compatibility problem", e);
+        }
 
         // Toku sometimes gets stuck without this hint:
         if (indexFilter.containsField(MongoDBRiver.MONGODB_ID_FIELD)) {


### PR DESCRIPTION
I've tested the latest river version with the different Mongo versions (at least with 2.6 and 3.0) and different mongo driver versions. Sometimes `cursor.disableBatchSizeTracking` throws the `NoSuchMethodError`. This is actually the only thing that works differently. If we ignore the error, indexing works as expected. So, may be, just ignore it?