### PR TITLE
Use loggers provided by AbstractRiverComponent, prefixed with river name

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/MongoConfigProvider.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/MongoConfigProvider.java
@@ -8,8 +8,6 @@ import java.util.concurrent.Callable;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.collect.ImmutableMap;
-import org.elasticsearch.common.logging.ESLogger;
-import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.river.mongodb.MongoConfig.Shard;
 
 import com.mongodb.BasicDBObject;
@@ -23,17 +21,16 @@ import com.mongodb.MongoClient;
 import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
 
-public class MongoConfigProvider implements Callable<MongoConfig> {
-
-    private static final ESLogger logger = ESLoggerFactory.getLogger(MongoConfigProvider.class.getName());
+public class MongoConfigProvider extends MongoDBRiverComponent implements Callable<MongoConfig> {
 
     private final MongoClientService mongoClientService;
     private final MongoDBRiverDefinition definition;
     private final MongoClient clusterClient;
 
-    public MongoConfigProvider(MongoClientService mongoClientService, MongoDBRiverDefinition definition) {
+    public MongoConfigProvider(MongoDBRiver river, MongoClientService mongoClientService) {
+        super(river);
         this.mongoClientService = mongoClientService;
-        this.definition= definition;
+        this.definition = river.definition;
         this.clusterClient = mongoClientService.getMongoClusterClient(definition);
     }
 

--- a/src/main/java/org/elasticsearch/river/mongodb/MongoDBRiverBulkProcessor.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/MongoDBRiverBulkProcessor.java
@@ -31,18 +31,15 @@ import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.collect.ImmutableMap;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.collect.Maps;
-import org.elasticsearch.common.logging.ESLogger;
-import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.river.mongodb.util.MongoDBRiverHelper;
 import org.elasticsearch.threadpool.ThreadPool.Info;
 import org.elasticsearch.threadpool.ThreadPoolStats.Stats;
 
-public class MongoDBRiverBulkProcessor {
+public class MongoDBRiverBulkProcessor extends MongoDBRiverComponent {
 
     public static final long DEFAULT_BULK_QUEUE_SIZE = 50;
     public static final Map<String, Boolean> DROP_INDEX = ImmutableMap.of("dropIndex", Boolean.TRUE);
-    private final ESLogger logger = ESLoggerFactory.getLogger(this.getClass().getName());
     private final MongoDBRiver river;
     private final MongoDBRiverDefinition definition;
     private final Client client;
@@ -159,6 +156,7 @@ public class MongoDBRiverBulkProcessor {
     };
 
     MongoDBRiverBulkProcessor(MongoDBRiver river, MongoDBRiverDefinition definition, Client client, String index, String type) {
+        super(river);
         this.river = river;
         this.bulkProcessor = BulkProcessor.builder(client, listener).setBulkActions(definition.getBulk().getBulkActions())
                 .setConcurrentRequests(definition.getBulk().getConcurrentRequests())

--- a/src/main/java/org/elasticsearch/river/mongodb/MongoDBRiverComponent.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/MongoDBRiverComponent.java
@@ -1,0 +1,10 @@
+package org.elasticsearch.river.mongodb;
+
+import org.elasticsearch.river.AbstractRiverComponent;
+
+public abstract class MongoDBRiverComponent extends AbstractRiverComponent {
+
+    protected MongoDBRiverComponent(MongoDBRiver river) {
+        super(river.riverName(), river.settings());
+    }
+}

--- a/src/main/java/org/elasticsearch/river/mongodb/StatusChecker.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/StatusChecker.java
@@ -1,17 +1,15 @@
 package org.elasticsearch.river.mongodb;
 
-import org.elasticsearch.common.logging.ESLogger;
-import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.river.mongodb.util.MongoDBRiverHelper;
 
-class StatusChecker implements Runnable {
-    private static final ESLogger logger = ESLoggerFactory.getLogger(StatusChecker.class.getName());
+class StatusChecker extends MongoDBRiverComponent implements Runnable {
 
     private final MongoDBRiver mongoDBRiver;
     private final MongoDBRiverDefinition definition;
     private final SharedContext context;
 
     public StatusChecker(MongoDBRiver mongoDBRiver, MongoDBRiverDefinition definition, SharedContext context) {
+        super(mongoDBRiver);
         this.mongoDBRiver = mongoDBRiver;
         this.definition = definition;
         this.context = context;
@@ -29,7 +27,7 @@ class StatusChecker implements Runnable {
                     } else if (status == Status.STOPPED) {
                         logger.info("About to stop river: {}", this.definition.getRiverName());
                         mongoDBRiver.internalStopRiver();
-                     }
+                    }
                 }
                 Thread.sleep(1000L);
             } catch (InterruptedException e) {


### PR DESCRIPTION
When you're running more than one river, it's very helpful if all log messages specific to a particular river include the river name.  Extending AbstractRiverComponent automatically creates a logger which does that, and more.