### PR TITLE
Mongo dbref expansion

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/Indexer.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/Indexer.java
@@ -414,7 +414,14 @@ class Indexer extends MongoDBRiverComponent implements Runnable {
      * @return
      */
     private Map<String, Object> convertDbRef(DBRef ref) {
-        Map<String, Object> obj = new HashMap<String, Object>();
+        DBObject dbObject = ref.fetch();
+        if(dbObject == null){
+            dbObject = ref.getDB().getMongo().getDB(definition.getMongoDb()).getCollection(ref.getRef()).findOne(new BasicDBObject("_id", ref.getId()));
+        }
+        if(dbObject != null) {
+            return createObjectMap(dbObject);
+        }
+        Map<String, Object> obj = new HashMap<>();
         obj.put("id", ref.getId());
         obj.put("ref", ref.getRef());
 

--- a/src/test/java/org/elasticsearch/river/mongodb/simple/test-simple-mongodb-referenced-document.json
+++ b/src/test/java/org/elasticsearch/river/mongodb/simple/test-simple-mongodb-referenced-document.json
@@ -1,0 +1,5 @@
+{
+  "_id": { "$oid" : "5194272CFDEA65E5D6000021" },
+  "name": "arbitrary category for a thousand",
+  "postDate": { "$date": 1388853809000.000000 }
+}


### PR DESCRIPTION
expand and nest dbrefs instead of mapping them as just the id and type


The following (where category is a dbref)
```
 {
      "_id" : "51a220fdb573df1144000000",
      "_source":{
          "body":"the body",
          "category":{"ref":"category","id":"5194272cfdea65e5d6000021"}
          }
      }
  }

```

Becomes
```
 {
      "_id" : "51a220fdb573df1144000000",
      "_source":{
          "body":"the body",
          "category":{
            "_id":"5194272cfdea65e5d6000021",
            "name":"arbitrary category for a thousand"
          }
      }
  }
```