### PR TITLE
Clean up #importInitial()

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/CollectionSlurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/CollectionSlurper.java
@@ -73,26 +73,13 @@ class CollectionSlurper extends MongoDBRiverComponent {
                 DBCollection collection = slurpedDb.getCollection(definition.getMongoCollection());
                 importCollection(collection, timestamp);
             }
-            logger.debug("Before waiting for 500 ms");
-            Thread.sleep(500);
         } catch (MongoInterruptedException | InterruptedException e) {
-            logger.info("river-mongodb slurper interrupted");
+            logger.error("river-mongodb slurper interrupted");
             Thread.currentThread().interrupt();
-            return;
-        } catch (MongoSocketException | MongoTimeoutException | MongoCursorNotFoundException e) {
-            logger.info("Oplog tailing - {} - {}. Will retry.", e.getClass().getSimpleName(), e.getMessage());
-            logger.debug("Total documents inserted so far: {}", totalDocuments.get());
-            try {
-                Thread.sleep(MongoDBRiver.MONGODB_RETRY_ERROR_DELAY_MS);
-            } catch (InterruptedException iEx) {
-                logger.info("river-mongodb slurper interrupted");
-                Thread.currentThread().interrupt();
-                return;
-            }
         } catch (Exception e) {
-            logger.error("Exception while looping in cursor", e);
+            logger.error("Exception in initial import", e);
+            logger.debug("Total documents inserted so far: {}", totalDocuments.get());
             Thread.currentThread().interrupt();
-            return;
         }
     }
 


### PR DESCRIPTION
This code was partially copy/pasted from the oplog slurper, but the exception handling
was not changed for the new environment: there is no retrying here.

* drop the unneeded Thread#sleep() calls
* drop the unneeded early returns
* change exception logging from #info() with #error()

The calls to Thread#interrupt() still make sense, as the slurper runs inside a thread,
and *that* one needs to stop as well.