### PR TITLE
Keep timestamps of rivers closer in sync with oplog

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/Indexer.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/Indexer.java
@@ -111,6 +111,11 @@ class Indexer extends MongoDBRiverComponent implements Runnable {
             return;
         }
 
+        if (operation == Operation.NOP) {
+            // No-op entry, nothing to do.
+            return;
+        }
+
         String type;
         if (definition.isImportAllCollections()) {
             type = entry.getCollection();

--- a/src/main/java/org/elasticsearch/river/mongodb/Operation.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/Operation.java
@@ -7,6 +7,12 @@ public enum Operation {
     DROP_COLLECTION("dc"),
     DROP_DATABASE("dd"),
     COMMAND(MongoDBRiver.OPLOG_COMMAND_OPERATION),
+    /**
+     * Internal "no-op" to force a timestamp update.
+     *
+     * The code is the same MongoDB uses for no-operation entries.
+     */
+    NOP("n"),
     UNKNOWN(null);
 
     private String value;

--- a/src/main/java/org/elasticsearch/river/mongodb/OplogSlurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/OplogSlurper.java
@@ -156,7 +156,7 @@ class OplogSlurper extends MongoDBRiverComponent implements Runnable {
         }
     }
 
-    private DBCursor processFullOplog() throws InterruptedException, SlurperException {
+    private DBCursor processFullOplog() throws SlurperException {
         Timestamp<?> currentTimestamp = getCurrentOplogTimestamp();
         return oplogCursor(currentTimestamp);
     }

--- a/src/main/java/org/elasticsearch/river/mongodb/OplogSlurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/OplogSlurper.java
@@ -205,7 +205,7 @@ class OplogSlurper extends MongoDBRiverComponent implements Runnable {
         logger.trace("namespace: {} - operation: {}", namespace, operation);
         if (namespace.equals(MongoDBRiver.OPLOG_ADMIN_COMMAND)) {
             if (operation == Operation.COMMAND) {
-                processAdminCommandOplogEntry(entry, startTimestamp);
+                processAdminCommandOplogEntry(entry);
                 return startTimestamp;
             }
         }
@@ -306,7 +306,7 @@ class OplogSlurper extends MongoDBRiverComponent implements Runnable {
         return oplog == null ? null : oplog.get("ops");
     }
 
-    private void processAdminCommandOplogEntry(final DBObject entry, final Timestamp<?> startTimestamp) throws InterruptedException {
+    private void processAdminCommandOplogEntry(final DBObject entry) throws InterruptedException {
         if (logger.isTraceEnabled()) {
             logger.trace("processAdminCommandOplogEntry - [{}]", entry);
         }

--- a/src/main/java/org/elasticsearch/river/mongodb/OplogSlurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/OplogSlurper.java
@@ -514,15 +514,10 @@ class OplogSlurper extends MongoDBRiverComponent implements Runnable {
         }
     }
 
-    private String addInsertToStream(final Timestamp<?> currentTimestamp, final DBObject data, final String collection)
+    private void addInsertToStream(final Timestamp<?> currentTimestamp, final DBObject data, final String collection)
             throws InterruptedException {
         totalDocuments.incrementAndGet();
         addToStream(Operation.INSERT, currentTimestamp, data, collection);
-        if (data == null) {
-            return null;
-        } else {
-            return data.containsField(MongoDBRiver.MONGODB_ID_FIELD) ? data.get(MongoDBRiver.MONGODB_ID_FIELD).toString() : null;
-        }
     }
 
     private void addToStream(final Operation operation, final Timestamp<?> currentTimestamp, final DBObject data, final String collection)

--- a/src/main/java/org/elasticsearch/river/mongodb/OplogSlurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/OplogSlurper.java
@@ -94,18 +94,36 @@ class OplogSlurper extends MongoDBRiverComponent implements Runnable {
                     if (cursor == null) {
                         cursor = processFullOplog();
                     }
-                    while (cursor.hasNext()) {
-                        DBObject item = cursor.next();
-                        // TokuMX secondaries can have ops in the oplog that
-                        // have not yet been applied
-                        // We need to wait until they have been applied before
-                        // processing them
-                        Object applied = item.get("a");
-                        if (applied != null && !applied.equals(Boolean.TRUE)) {
-                            logger.debug("Encountered oplog entry with a:false, ts:" + item.get("ts"));
-                            break;
+                    // Block until #hasNext(), then consume all the items visible,
+                    // and then proceed back to blocking until the cursor is killed on the server side,
+                    // or we're interrupted.
+                    logger.debug("Starting blocking wait for cursor");
+                    BLOCKING: while (cursor.hasNext()) {
+                        int processedOplogItems = 0;
+                        int newEntries = 0;
+                        DBObject item;
+                        while ((item = cursor.tryNext()) != null) {
+                            // TokuMX secondaries can have ops in the oplog that
+                            // have not yet been applied
+                            // We need to wait until they have been applied before
+                            // processing them
+                            Object applied = item.get("a");
+                            if (applied != null && !applied.equals(Boolean.TRUE)) {
+                                logger.debug("Encountered oplog entry with a:false, ts:" + item.get("ts"));
+                                break BLOCKING;
+                            }
+                            newEntries += processOplogEntry(item, timestamp);
+                            processedOplogItems++;
+                            timestamp = Timestamp.on(item);
                         }
-                        timestamp = processOplogEntry(item, timestamp);
+                        logger.debug("Processed {} without blocking, generated {} indexer queue entries", processedOplogItems, newEntries);
+
+                        if (newEntries == 0) {
+                            // Add a NOP with that timestamp
+                            logger.debug("Inserting NOP");
+                            DBObject dummy = new BasicDBObject();
+                            addToStream(Operation.NOP, timestamp, dummy, null);
+                        }
                     }
                     logger.debug("Before waiting for 500 ms");
                     Thread.sleep(500);
@@ -161,7 +179,7 @@ class OplogSlurper extends MongoDBRiverComponent implements Runnable {
         return oplogCursor(currentTimestamp);
     }
 
-    private Timestamp<?> processOplogEntry(final DBObject entry, final Timestamp<?> startTimestamp) throws InterruptedException {
+    private int processOplogEntry(final DBObject entry, final Timestamp<?> startTimestamp) throws InterruptedException {
         // To support transactions, TokuMX wraps one or more operations in a
         // single oplog entry, in a list.
         // As long as clients are not transaction-aware, we can pretty safely
@@ -171,7 +189,7 @@ class OplogSlurper extends MongoDBRiverComponent implements Runnable {
         flattenOps(entry);
 
         if (!isValidOplogEntry(entry, startTimestamp)) {
-            return startTimestamp;
+            return 0;
         }
         Operation operation = Operation.fromString(entry.get(MongoDBRiver.OPLOG_OPERATION).toString());
         String namespace = entry.get(MongoDBRiver.OPLOG_NAMESPACE).toString();
@@ -193,7 +211,7 @@ class OplogSlurper extends MongoDBRiverComponent implements Runnable {
                 if (definition.isImportAllCollections()) {
                     collection = object.get(MongoDBRiver.OPLOG_DROP_COMMAND_OPERATION).toString();
                     if (collection.startsWith("tmp.mr.")) {
-                        return startTimestamp;
+                        return 0;
                     }
                 }
             }
@@ -206,7 +224,7 @@ class OplogSlurper extends MongoDBRiverComponent implements Runnable {
         if (namespace.equals(MongoDBRiver.OPLOG_ADMIN_COMMAND)) {
             if (operation == Operation.COMMAND) {
                 processAdminCommandOplogEntry(entry);
-                return startTimestamp;
+                return 0;
             }
         }
 
@@ -252,6 +270,7 @@ class OplogSlurper extends MongoDBRiverComponent implements Runnable {
             }
         }
 
+        int newEntries = 0;
         if (object instanceof GridFSDBFile) {
             if (objectId == null) {
                 throw new NullPointerException(MongoDBRiver.MONGODB_ID_FIELD);
@@ -259,21 +278,21 @@ class OplogSlurper extends MongoDBRiverComponent implements Runnable {
             if (logger.isTraceEnabled()) {
                 logger.trace("Add attachment: {}", objectId);
             }
-            addToStream(operation, oplogTimestamp, applyFieldFilter(object), collection);
+            newEntries = addToStream(operation, oplogTimestamp, applyFieldFilter(object), collection);
         } else {
             if (operation == Operation.UPDATE) {
                 DBObject update = (DBObject) entry.get(MongoDBRiver.OPLOG_UPDATE);
                 logger.trace("Updated item: {}", update);
-                addQueryToStream(operation, oplogTimestamp, update, collection);
+                newEntries = addQueryToStream(operation, oplogTimestamp, update, collection);
             } else {
                 if (operation == Operation.INSERT) {
-                    addInsertToStream(oplogTimestamp, applyFieldFilter(object), collection);
+                    newEntries = addInsertToStream(oplogTimestamp, applyFieldFilter(object), collection);
                 } else {
-                    addToStream(operation, oplogTimestamp, applyFieldFilter(object), collection);
+                    newEntries = addToStream(operation, oplogTimestamp, applyFieldFilter(object), collection);
                 }
             }
         }
-        return oplogTimestamp;
+        return newEntries;
     }
 
     @SuppressWarnings("unchecked")
@@ -488,39 +507,43 @@ class OplogSlurper extends MongoDBRiverComponent implements Runnable {
         }
     }
 
-    private void addQueryToStream(final Operation operation, final Timestamp<?> currentTimestamp, final DBObject update,
+    private int addQueryToStream(final Operation operation, final Timestamp<?> currentTimestamp, final DBObject update,
             final String collection) throws InterruptedException {
         if (logger.isTraceEnabled()) {
             logger.trace("addQueryToStream - operation [{}], currentTimestamp [{}], update [{}]", operation, currentTimestamp, update);
         }
 
         if (collection == null) {
+            int newEntries = 0;
             for (String name : slurpedDb.getCollectionNames()) {
                 DBCollection slurpedCollection = slurpedDb.getCollection(name);
-                addQueryToStream(operation, currentTimestamp, update, name, slurpedCollection);
+                newEntries += addQueryToStream(operation, currentTimestamp, update, name, slurpedCollection);
             }
+            return newEntries;
         } else {
             DBCollection slurpedCollection = slurpedDb.getCollection(collection);
-            addQueryToStream(operation, currentTimestamp, update, collection, slurpedCollection);
+            return addQueryToStream(operation, currentTimestamp, update, collection, slurpedCollection);
         }
     }
 
-    private void addQueryToStream(final Operation operation, final Timestamp<?> currentTimestamp, final DBObject update,
+    private int addQueryToStream(final Operation operation, final Timestamp<?> currentTimestamp, final DBObject update,
                 final String collection, final DBCollection slurpedCollection) throws InterruptedException {
         try (DBCursor cursor = slurpedCollection.find(update, findKeys)) {
+            int newEntries = 0;
             for (DBObject item : cursor) {
-                addToStream(operation, currentTimestamp, item, collection);
+                newEntries += addToStream(operation, currentTimestamp, item, collection);
             }
+            return newEntries;
         }
     }
 
-    private void addInsertToStream(final Timestamp<?> currentTimestamp, final DBObject data, final String collection)
+    private int addInsertToStream(final Timestamp<?> currentTimestamp, final DBObject data, final String collection)
             throws InterruptedException {
         totalDocuments.incrementAndGet();
-        addToStream(Operation.INSERT, currentTimestamp, data, collection);
+        return addToStream(Operation.INSERT, currentTimestamp, data, collection);
     }
 
-    private void addToStream(final Operation operation, final Timestamp<?> currentTimestamp, final DBObject data, final String collection)
+    private int addToStream(final Operation operation, final Timestamp<?> currentTimestamp, final DBObject data, final String collection)
             throws InterruptedException {
         if (logger.isTraceEnabled()) {
             String dataString = data.toString();
@@ -537,16 +560,21 @@ class OplogSlurper extends MongoDBRiverComponent implements Runnable {
             logger.info("addToStream - Operation.DROP_DATABASE, currentTimestamp [{}], data [{}], collection [{}]",
                     currentTimestamp, data, collection);
             if (definition.isImportAllCollections()) {
+                int newEntries = 0;
                 for (String name : slurpedDb.getCollectionNames()) {
                     logger.info("addToStream - isImportAllCollections - Operation.DROP_DATABASE, currentTimestamp [{}], data [{}], collection [{}]",
                             currentTimestamp, data, name);
                     context.getStream().put(new MongoDBRiver.QueueEntry(currentTimestamp, Operation.DROP_COLLECTION, data, name));
+                    newEntries++;
                 }
+                return newEntries;
             } else {
                 context.getStream().put(new MongoDBRiver.QueueEntry(currentTimestamp, Operation.DROP_COLLECTION, data, collection));
+                return 1;
             }
         } else {
             context.getStream().put(new MongoDBRiver.QueueEntry(currentTimestamp, operation, data, collection));
+            return 1;
         }
     }
 


### PR DESCRIPTION
(Pretty much copied from 56c6408, the other commits are just cleanups to make the "big one" easier to read as diff)

When scanning the oplog there are many entries that are not directly relevant for the current river: administrative messages, no-op entries, entries for other collections, ... .
Previously we simply ignored these.

This "ignoring" does have quite grave consequences:
1. When the river is restarted it may have to re-process many of them, especially when it is a for a collection with little activity, in a database with very active other collections.
2. As a direct consequence of that the amount of oplog entries that need to be available must be such that of _every_ collection the newest eligible entry is still in the collection.

Especially the last point is problematic when the cluster topology itself is very dynamic, as it can happen in automatically managed clusters in a cloud environment. [see below]

This commit changes the approach so that for each bulk of oplog entries at least the timestamp in the river state is updated: either because there was at least one eligible entry, or, failing that, by introducing a "no-op" request into the index stream.
## 

The problem I observed is that I started to let AWS' autoscaling manage our cluster of `mongod`s, which means that the PRIMARY moves around quite often - with "move" meaning "instance gets completely replaced". Whenever such a move happened my rivers started becoming stale, and needed to be recreated.

This patch set fixes that for the common case of an orderly shutdown of mongod, because we no longer need to have access to old oplog entries as long as the river can follow the oplog closely, and write the timestamp information out quickly enough.
